### PR TITLE
Android 16kb page size

### DIFF
--- a/DEPS.xwalk
+++ b/DEPS.xwalk
@@ -20,7 +20,7 @@
 #orig 
 #chromium_crosswalk_rev = 'dd39e4fbbc1e4417cef2f908cc0a42af1e2120aa'
 
-chromium_crosswalk_rev = 'dd34c592a78832912275550dc81d6e131098345d'
+chromium_crosswalk_rev = '30ba7a518bfd9882a50fd31308950e60e2100768'
 #'9a967afdddfb7b7af327681f52c1f92b83944f3c'
 #ab583b52a0576ccf60c791df6642f0ee195291d0'
 #5d68d90dcaff8042649baabca842f28249a95036'

--- a/runtime/app/android/BUILD.gn
+++ b/runtime/app/android/BUILD.gn
@@ -3,6 +3,16 @@
 # found in the LICENSE file.
 import("//xwalk/build/tenta.gni")
 
+# Custom linker flags for arm64 builds
+config("xwalk_arm64_ldflags") {
+  if (is_android && target_cpu == "arm64") {
+    ldflags = [
+      "-Wl,-z,max-page-size=16384",
+      "-Wl,-z,common-page-size=16384",
+    ]
+  }
+}
+
 shared_library("libxwalkcore") {
   sources = [
     "xwalk_entry_point.cc",
@@ -28,6 +38,7 @@ shared_library("libxwalkcore") {
     #has common meta_logging.h
     "//xwalk/runtime/android/empty_tenta",
   ]
+  configs += [ ":xwalk_arm64_ldflags" ]
   if (tenta_chromium_build) {
     deps += [
       "//xwalk/third_party/tenta/meta_fs",


### PR DESCRIPTION
Google requires native libraries to support 16kB page sizes by Nov 1 2025: https://developer.android.com/guide/practices/page-sizes

This pull requests adds support for runtime page size to Android ARM64 builds.